### PR TITLE
Shell out to the OS instead of invoking yarn directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2372,7 +2372,7 @@ checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "wasmer-pack"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -2392,7 +2392,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-pack-cli"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2413,7 +2413,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-pack-testing"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "ignore",
@@ -2427,7 +2427,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-pack-wasm"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "wai-bindgen-rust",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/wasmerio/wasmer-pack"
 rust-version = "1.64.0"                                       # Required for [workspace.package]
-version = "0.6.0"
+version = "0.6.1"


### PR DESCRIPTION
## Description
`yarn`/`npm` is a script on windows rather than a inbuilt command so shelling it out is necessary on windows.

## Context
Yarn command on windows was not working so a fix was inspired from [wapm-cli](https://github.com/wasmerio/wapm-cli/pull/292).

## Checklist
 - [x] Fixed Yarn and Jest tests on windows

- Is this a user-facing change? If so, update [`CHANGELOG.md`](https://github.com/wasmerio/wasmer-pack/blob/master/CHANGELOG.md)
- Does this include an architectural decision? If so, add a quick [Architectural Decision Record](https://wasmerio.github.io/wasmer-pack/user-docs/architecture/#architecture-decision-records)
