### PR TITLE
added slash filter to settings for insta settings

### DIFF
--- a/crates/testing/src/autodiscover.rs
+++ b/crates/testing/src/autodiscover.rs
@@ -104,6 +104,10 @@ fn snapshot_generated_bindings(
     settings.set_omit_expression(true);
     settings.add_filter(r"wasmer-pack v\d+\.\d+\.\d+", "wasmer-pack vX.Y.Z");
 
+    if cfg!(target_os = "windows") {
+        settings.add_filter(r"\\\\", "/");
+    }
+
     let _guard = settings.bind_to_scope();
 
     insta::assert_debug_snapshot!(


### PR DESCRIPTION
Windows uses `\\` while unix systems use `/` for paths so a filter was needed to check if the path had `\\`. it is to be replaced by `/` on windows.